### PR TITLE
fix infinite loop in map()

### DIFF
--- a/utils/mapper.py
+++ b/utils/mapper.py
@@ -52,7 +52,7 @@ def map_folder_from_unmapped(unmapped_folders):
         [None, 'to skip): ']
     ]))
     if user_input == 's':
-        unmapped_folders = []
+        unmapped_folders.clear()
         return
     
     try:


### PR DESCRIPTION
The unmapped_folders list would fail to clear after pressing 's' to skip, causing the while loop in map() to never close.